### PR TITLE
Add missing re-exports

### DIFF
--- a/nix-derivation.cabal
+++ b/nix-derivation.cabal
@@ -1,5 +1,5 @@
 Name: nix-derivation
-Version: 1.1.0
+Version: 1.1.1
 Cabal-Version: >=1.10
 Build-Type: Simple
 Tested-With: GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.2, GHC == 8.8.3

--- a/src/Nix/Derivation.hs
+++ b/src/Nix/Derivation.hs
@@ -83,9 +83,12 @@ module Nix.Derivation
 
       -- * Parse derivations
     , parseDerivation
+    , parseDerivationWith
+    , textParser
 
       -- * Render derivations
     , buildDerivation
+    , buildDerivationWith
     ) where
 
 import Nix.Derivation.Builder

--- a/src/Nix/Derivation/Parser.hs
+++ b/src/Nix/Derivation/Parser.hs
@@ -9,6 +9,7 @@ module Nix.Derivation.Parser
     ( -- * Parser
       parseDerivation
     , parseDerivationWith
+    , textParser
     ) where
 
 import Data.Attoparsec.Text.Lazy (Parser)


### PR DESCRIPTION
I've missed that the `.Parser` and `.Builder` are part of `other-modules`.

Managed  to successfully integrate at
https://github.com/haskell-nix/hnix-store/pull/59/commits/6504df706d06dfd4783a4d7f919fad2bb8a4312d#diff-2ae9934eb7f151fa934ade9c05a9bb26R23