### PR TITLE
Bump QuickCheck dep from < 2.14 to < 2.15

### DIFF
--- a/nix-derivation.cabal
+++ b/nix-derivation.cabal
@@ -77,7 +77,7 @@ Test-Suite property
         base            >= 4.6.0.0  && < 5   ,
         attoparsec      >= 0.12.0.0 && < 0.14,
         nix-derivation                       ,
-        QuickCheck                     < 2.14,
+        QuickCheck                     < 2.15,
         text            >= 0.8.0.0  && < 1.3 ,
         vector                         < 0.13,
         filepath                       < 1.5


### PR DESCRIPTION
We recently got QuickCheck-2.14.2 in Nixpkgs, and `nix-derivation` is no longer able to be built without jailbreaking.

It would be great to get a release of nix-derivation with this dependency bump (or even just a Hackage revision).